### PR TITLE
Include git clone instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ The scripts were tested using a host machine running [Ubuntu](http://www.ubuntu.
 
 The scripts may work in other UNIX environments as well. See the [Questions & Answers](http://pndaproject.io/qa) site for further information.
 
+## Pull in the repo
+
+Before you can build the package server container, you must clone the repository onto your host machine:
+
+`git clone https://github.com/pndaproject/pnda-package-server-docker`
+
+Now change directory into `pnda-package-server-docker`
+
 ## Building the package server container
 
 TODO: push the docker images to a registry.


### PR DESCRIPTION
Git clone instruction for pnda-package-server-docker repo missing from instruction set.